### PR TITLE
Remove until-build limit of idea-version plugin definition

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor email="haskin.dev@gmail.com" url="https://www.haskin.dev">haskin</vendor>
 
-    <idea-version since-build="213" until-build="223.*"/>
+    <idea-version since-build="213"/>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.


### PR DESCRIPTION
As a result of experiment I removed the until-build limit of idea-version plugin definition in order to make it work with the latest version of IntelliJ Goland IDE.